### PR TITLE
chore: upgrate netlify cms version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "gatsby-plugin-google-analytics": "^4.19.0",
         "gatsby-plugin-less": "^6.19.0",
         "gatsby-plugin-manifest": "^4.19.0",
-        "gatsby-plugin-netlify-cms": "^6.19.0",
+        "gatsby-plugin-netlify-cms": "^6.25.0",
         "gatsby-plugin-offline": "^5.19.0",
         "gatsby-plugin-react-helmet": "^5.19.0",
         "gatsby-plugin-readingtime": "^2.2.0",
@@ -12201,9 +12201,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gatsby-plugin-netlify-cms": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-6.19.0.tgz",
-      "integrity": "sha512-mi4ABDIQ0xXgy3XSW2Vo1zWUGr5AbmR+Yy8LirPkvhbHTVXPevI8qhpMbLsn5KwsPxh7WuvohoRn6n94bwH6pA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-6.25.0.tgz",
+      "integrity": "sha512-wBgEVrtdGFDo7hst+y7RcYodckWy6JXDauM8BLtXQ2CVOG1T4ircsyXEjifWCDKyI4TlaPpg5x7no/SCpAHIMw==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@soda/friendly-errors-webpack-plugin": "1.8.1",
@@ -12221,8 +12221,8 @@
       "peerDependencies": {
         "gatsby": "^4.0.0-next",
         "netlify-cms-app": "^2.9.0",
-        "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0 || ^0.0.0",
         "webpack": "^5.0.0"
       }
     },
@@ -36127,9 +36127,9 @@
       }
     },
     "gatsby-plugin-netlify-cms": {
-      "version": "6.19.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-6.19.0.tgz",
-      "integrity": "sha512-mi4ABDIQ0xXgy3XSW2Vo1zWUGr5AbmR+Yy8LirPkvhbHTVXPevI8qhpMbLsn5KwsPxh7WuvohoRn6n94bwH6pA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-netlify-cms/-/gatsby-plugin-netlify-cms-6.25.0.tgz",
+      "integrity": "sha512-wBgEVrtdGFDo7hst+y7RcYodckWy6JXDauM8BLtXQ2CVOG1T4ircsyXEjifWCDKyI4TlaPpg5x7no/SCpAHIMw==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@soda/friendly-errors-webpack-plugin": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gatsby-plugin-google-analytics": "^4.19.0",
     "gatsby-plugin-less": "^6.19.0",
     "gatsby-plugin-manifest": "^4.19.0",
-    "gatsby-plugin-netlify-cms": "^6.19.0",
+    "gatsby-plugin-netlify-cms": "^6.25.0",
     "gatsby-plugin-offline": "^5.19.0",
     "gatsby-plugin-react-helmet": "^5.19.0",
     "gatsby-plugin-readingtime": "^2.2.0",
@@ -53,9 +53,7 @@
     "prettier": "^2.7.1"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",
-  "keywords": [
-    "gatsby"
-  ],
+  "keywords": ["gatsby"],
   "license": "MIT",
   "main": "n/a",
   "repository": {


### PR DESCRIPTION
This upgrades netlify-cms from 6.19.0 to 6.25.0.

This is an attempt to try and fix a broken login logic for netlify cms.