### PR TITLE
fix: slug link in tags list

### DIFF
--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -78,6 +78,7 @@ export const pageQuery = graphql`
             date(formatString: "MMMM DD, YYYY")
             title
             tags
+            slug
             featureImage {
               childImageSharp {
                 fluid(maxWidth: 630) {


### PR DESCRIPTION
This fixes an issue on the tags post page.
Now, clicking on posts on the tags page will open the post.

/schedule